### PR TITLE
Added Cursor-formatted versions of the frontend rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 This repository contains standardized rules to improve code generation and maintain consistency across Trengo repositories. These rules help teams follow best practices and reduce errors when developing with modern tooling and AI assistance.
 
+> This repository also provides rules formatted for Cursor, allowing teams using Cursor to benefit from the same standards in an automated way.
+
 ## 🗂️ Repository Structure
 
 ```
@@ -17,6 +19,8 @@ This repository contains standardized rules to improve code generation and maint
     ui/                 # Rules for the UI components library
     icons/              # Rules for the icons library
     ai-helpmate/        # Rules for the AI helpmate frontend
+  cursor-rules/
+    frontend/           # Cursor-formatted rules for the main frontend repository
   README.md             # This file
 ```
 
@@ -49,6 +53,20 @@ This repository contains standardized rules to improve code generation and maint
 | ---------------------------------------------------------------------- | ------------------------------------------------------ |
 | [📋 General Guidelines](./rules/ai-helpmate/00-general-guidelines.mdc) | Project structure, component organization, and testing |
 | [📦 Modules Structure](./rules/ai-helpmate/01-modules.mdc)             | Module organization, communication, and registration   |
+
+## 🖱️ Cursor Rules
+
+These rules are formatted for use with Cursor and follow Cursor's standards for rule definition and automation.
+
+> **Note:** The rules in `cursor-rules/frontend` are the same as those in `rules/frontend`, but are reformatted to meet Cursor's standards for rule definition and automation. This ensures consistency while enabling automated rule enforcement in Cursor.
+
+### 🖱️ Frontend Rules (Cursor)
+
+| 📄 Rule File                                                                 | 📝 Description                                                                 |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [📌 General Guidelines](./cursor-rules/frontend/general.mdc)                 | Patterns and rules for code organization, file structure, and import practices |
+| [🧩 Component Patterns](./cursor-rules/frontend/component-patterns.mdc)      | Best practices for components, props, emits, composables, and forms           |
+| [⚡ Performance Guidelines](./cursor-rules/frontend/perfromance.mdc)          | Performance tips for components, rendering, async ops, and asset optimization |
 
 ## 🚀 How to Use These Rules
 

--- a/cursor-rules/frontend/component-patterns.mdc
+++ b/cursor-rules/frontend/component-patterns.mdc
@@ -1,0 +1,62 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+### Pattern
+
+src/components/**/*.vue
+
+### Rule
+
+Components should follow the Single Responsibility Principle. Break large components into smaller ones. Use props and emits for communication — avoid accessing `$parent` or `$children`. Use slots for content injection when appropriate.
+
+---
+
+### Pattern
+
+src/components/**/*.vue
+
+### Rule
+
+All props must have TypeScript type definitions. Use default values for optional props. Document complex props with comments. Use camelCase for prop names in the script section and kebab-case when used in the template.
+
+---
+
+### Pattern
+
+src/components/**/*.vue
+
+### Rule
+
+Define emits with proper types. Use kebab-case for event names. Avoid using the global event bus for communication.
+
+---
+
+### Pattern
+
+src/composables/use*.ts
+
+### Rule
+
+Extract reusable logic into composables. Name each composable with the `use` prefix (e.g., `useTickets`). Composables should follow the Single Responsibility Principle and return only necessary values. Document their purpose and usage.
+
+---
+
+### Pattern
+
+src/store/**/*.ts
+
+### Rule
+
+Use Pinia for state management in new features. Organize stores by feature. Keep each store small and focused. Use getters for derived state and actions for side effects or mutations.
+
+---
+
+### Pattern
+
+src/components/forms/**/*.vue
+
+### Rule
+
+Use `vee-validate` or a similar library for form validation. Separate form logic into dedicated composables. Handle form submission consistently. Provide user-friendly error feedback. Ensure support for both keyboard and mouse interactions.

--- a/cursor-rules/frontend/general.mdc
+++ b/cursor-rules/frontend/general.mdc
@@ -1,0 +1,85 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+### Pattern
+
+src/**/*.{ts,vue}
+
+### Rule
+
+Use TypeScript for all new code. Prefer the Vue 3 Composition API and `<script setup>` syntax. Keep components focused on a single responsibility.
+
+---
+
+### Pattern
+
+src/store/**/*.ts
+
+### Rule
+
+Use the `store/` directory for all Pinia or Vuex state logic. Keep state, actions, and getters in clearly separated files where appropriate.
+
+---
+
+### Pattern
+
+src/composables/**/*.ts
+
+### Rule
+
+Reusable logic should be placed in the `composables/` directory. Use camelCase filenames and return composables as functions.
+
+---
+
+### Pattern
+
+src/utils/**/*.ts
+
+### Rule
+
+Utility functions go in the `util/` directory. Files should be named using camelCase. Each function should be pure and reusable.
+
+---
+
+### Pattern
+
+src/components/**/*.vue
+
+### Rule
+
+Vue component filenames should use PascalCase (e.g., `MyComponent.vue`). Use `<script setup lang="ts">`. Structure component files with template at the top, script in the middle, style at the bottom. Use scoped styles by default.
+
+---
+
+### Pattern
+
+src/components/**/index.ts
+
+### Rule
+
+Use an `index.ts` file to export multiple components within the same directory. Group related components in a feature-specific folder.
+
+---
+
+### Pattern
+
+src/**/*.{ts,vue}
+
+### Rule
+
+Follow import best practices:
+- Use named imports over default imports.
+- Order imports: external libraries, internal modules, then relative imports.
+- Use relative imports within the same feature, and `@/` for cross-feature imports.
+
+---
+
+### Pattern
+
+src/components/**
+
+### Rule
+
+Use feature-based folder organization. Shared or global components should go directly under `src/components/`. Feature-specific components should be in subfolders like `src/components/my-feature/`.

--- a/cursor-rules/frontend/perfromance.mdc
+++ b/cursor-rules/frontend/perfromance.mdc
@@ -1,0 +1,72 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+### Pattern
+
+src/components/**/*.vue
+
+### Rule
+
+Use `v-show` instead of `v-if` for elements that toggle frequently. Prefer computed properties over methods for derived values. Use `shallowRef` for large non-reactive objects. Avoid unnecessary watchers. For simple, stateless components, use functional components.
+
+---
+
+### Pattern
+
+src/components/**/*.vue
+
+### Rule
+
+Optimize rendering performance by:
+- Using unique and stable keys in `v-for` loops
+- Avoiding expensive computations inside computed properties
+- Applying `v-once` for static content
+- Lazy loading components when possible
+- Using `<Suspense>` for async components
+
+---
+
+### Pattern
+
+src/**/*.{ts,vue}
+
+### Rule
+
+Handle async operations efficiently:
+- Prefer `async/await` over raw Promises
+- Manage loading and error states in UI
+- Debounce or throttle event handlers to reduce performance impact
+- Cancel or avoid redundant API requests
+
+---
+
+### Pattern
+
+src/router/**/*.ts
+
+### Rule
+
+Lazy load routes using dynamic `import()` to reduce initial bundle size. Avoid loading unnecessary modules at startup.
+
+---
+
+### Pattern
+
+src/**/*.{ts,vue}
+
+### Rule
+
+Use dynamic imports for large dependencies. Import only what you use from third-party libraries to benefit from tree-shaking and avoid unnecessary bundle bloat.
+
+---
+
+### Pattern
+
+public/**/*.{png,jpg,jpeg,webp,svg}
+src/assets/**/*.{png,jpg,jpeg,webp,svg}
+
+### Rule
+
+Optimize images before use. Prefer WebP format where supported. Set proper `width` and `height` attributes on images for layout stability. Use lazy loading for images. Favor SVG for icons. Consider a CDN for serving static assets.


### PR DESCRIPTION
### Changes

   - Added Cursor-formatted versions of the frontend rules in `cursor-rules/frontend`.
   - Updated README to document the new rules, clarify their relationship to the originals, and update the repository structure.