### PR TITLE
Fix duplicate front matter in performance.mdc

### DIFF
--- a/rules/cursor/frontend/performance.mdc
+++ b/rules/cursor/frontend/performance.mdc
@@ -1,9 +1,4 @@
 ---
-description: 
-globs: 
-alwaysApply: false
----
----
 description: "Performance optimization rules for Vue components and frontend assets"
 globs: ["src/**/*.{ts,vue}", "src/components/**/*.vue", "src/router/**/*.ts", "public/**/*.{png,jpg,jpeg,webp,svg}", "src/assets/**/*.{png,jpg,jpeg,webp,svg}"]
 alwaysApply: true


### PR DESCRIPTION
This PR fixes an issue with duplicate front matter in the performance.mdc file.

Changes made:
- Removed the empty front matter section at the beginning of the file
- Kept the complete front matter section with proper description, globs, and alwaysApply settings
- Maintained all existing patterns and rules

This change ensures proper parsing of the file and maintains consistency with other rule files.